### PR TITLE
Fix crashes caused by exceptions in async handlers

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,3 +1,4 @@
+import "@/patch-express";
 import process from "node:process";
 const cors = require('cors')
 import "dotenv/config";
@@ -7,6 +8,7 @@ import fs from 'fs';
 const swaggerUI = require('swagger-ui-express')
 import path from 'path';
 import OpenApiValidator from 'express-openapi-validator';
+import { Request, Response, NextFunction } from "express";
 
 // IMPORT FILES HERE
 import { router } from "@/router";
@@ -47,13 +49,9 @@ app.post('/register', registration.registerUser)
 app.post('/schedules', auth.authorizationCheck, schedules.create);
 app.get('/schedules', auth.authorizationCheck, schedules.list);
 
-app.use((err, req, res, next) => {
-  res.status(err.status).json({
-    message: err.message,
-    errors: err.errors,
-    status: err.status,
-  })
-
+app.use((err: Error, _rq: Request, res: Response, _next: NextFunction) => {
+  console.error(err);
+  res.status(500).send('Internal Server Error');
 })
 
 

--- a/server/src/patch-express.ts
+++ b/server/src/patch-express.ts
@@ -1,0 +1,67 @@
+/*
+Copied from https://github.com/davidbanham/express-async-errors
+to avoid bringing in another dependency
+
+Original work Copyright (c) 2016, Nikolay Nemshilov <nemshilov@gmail.com>
+Modified work Copyright (c) 2016, David Banham <david@banham.id.au>
+
+Permission to use, copy, modify, and/or distribute this software for any purpose
+with or without fee is hereby granted, provided that the above copyright notice
+and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+THIS SOFTWARE.
+*/
+
+const Layer = require("express/lib/router/layer");
+const Router = require("express/lib/router");
+
+const last = (arr = []) => arr[arr.length - 1];
+const noop = Function.prototype;
+
+function copyFnProps(oldFn, newFn) {
+  Object.keys(oldFn).forEach(key => {
+    newFn[key] = oldFn[key];
+  });
+  return newFn;
+}
+
+function wrap(fn) {
+  const newFn = function newFn(...args) {
+    const ret = fn.apply(this, args);
+    const next = (args.length === 5 ? args[2] : last(args)) || noop;
+    if (ret && ret.catch) ret.catch(err => next(err));
+    return ret;
+  };
+  Object.defineProperty(newFn, "length", {
+    value: fn.length,
+    writable: false,
+  });
+  return copyFnProps(fn, newFn);
+}
+
+function patchRouterParam() {
+  const originalParam = Router.prototype.constructor.param;
+  Router.prototype.constructor.param = function param(name, fn) {
+    fn = wrap(fn);
+    return originalParam.call(this, name, fn);
+  };
+}
+
+Object.defineProperty(Layer.prototype, "handle", {
+  enumerable: true,
+  get() {
+    return this.__handle;
+  },
+  set(fn) {
+    fn = wrap(fn);
+    this.__handle = fn;
+  },
+});
+
+patchRouterParam();


### PR DESCRIPTION
Express doesn't properly handle exceptions thrown in async handlers, so I found this library that patches express to fix it: <https://github.com/davidbanham/express-async-errors>. Instead of adding it I just copied the code because its like 50 lines.