### PR TITLE
Join Button closes modal and auto-regenerates cards

### DIFF
--- a/client/src/Home.tsx
+++ b/client/src/Home.tsx
@@ -65,7 +65,7 @@ export default function Home() {
       return `${formattedStart} - ${formattedEnd}`;
     }
 
-    return "Invalid start and/or end time";
+    return "No Shifts";
   };
 
   return (

--- a/client/src/Home.tsx
+++ b/client/src/Home.tsx
@@ -1,10 +1,10 @@
 import { Grid2 as Grid, Typography, Paper, Divider, Box } from "@mui/material";
-import { useState, useMemo } from "react";
+import { useState } from "react";
 import ResponsiveDrawer from "./LeftDrawer";
 import "dayjs/locale/en";
 import * as React from "react";
-import { useApi } from "@/client";
 import dayjs from "dayjs";
+import { useDatabaseQueries } from "@/hooks/useDatabaseQueries";
 
 const drawerWidth = 360;
 
@@ -16,7 +16,6 @@ interface LeftDrawerContextType {
   setMobileOpen: React.Dispatch<React.SetStateAction<boolean>>;
   isClosing: boolean;
   setIsClosing: React.Dispatch<React.SetStateAction<boolean>>;
-  refetchAllSchedules: () => void;
 }
 
 export const LeftDrawerContext = React.createContext<LeftDrawerContextType>({
@@ -24,38 +23,13 @@ export const LeftDrawerContext = React.createContext<LeftDrawerContextType>({
   setMobileOpen: () => {},
   isClosing: false,
   setIsClosing: () => {},
-  refetchAllSchedules: () => {},
 });
 
 export default function Home() {
   const [mobileOpen, setMobileOpen] = useState(false);
   const [isClosing, setIsClosing] = useState(false);
 
-  const api = useApi();
-
-  // Retrieve and create schedule array to display
-  const { data: scheduleData, refetch: refetchAllSchedules } = api.useQuery(
-    "get",
-    "/schedules",
-    {
-      headers: {
-        Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
-      },
-    },
-  );
-
-  const schedules = useMemo(
-    () =>
-      scheduleData?.map(schedule => ({
-        id: schedule.id,
-        name: schedule.name,
-        description: schedule.description,
-        state: schedule.state,
-        startTime: schedule.startTime,
-        endTime: schedule.endTime,
-      })),
-    [scheduleData],
-  );
+  const queries = useDatabaseQueries();
 
   // Making the times into readable format
   const formatTimes = (startTime: string | null, endTime: string | null) => {
@@ -85,7 +59,6 @@ export default function Home() {
           setMobileOpen,
           isClosing,
           setIsClosing,
-          refetchAllSchedules,
         }}
       >
         <Navbar />
@@ -124,7 +97,7 @@ export default function Home() {
           <Divider variant="middle" />
           <Grid container spacing={2} sx={{ padding: 2 }}>
             {/* Create a card from each schedule from query */}
-            {schedules?.map(schedule => (
+            {queries.schedules?.map(schedule => (
               <Grid size={{ xs: 12, sm: 6, md: 3 }} key={schedule.id}>
                 <ShiftTreeCard
                   name={schedule.name}

--- a/client/src/JoinTree.tsx
+++ b/client/src/JoinTree.tsx
@@ -11,19 +11,17 @@ import {
 import React, { useState } from "react";
 import { ModalContext } from "@/Navbar";
 import { useEmployeeActions } from "@/hooks/useEmployeeActions";
+import { useDatabaseQueries } from "@/hooks/useDatabaseQueries";
 
 interface JoinTreeProps {
   joinType: "ShiftTree" | "Organization";
-  refetchAllSchedules: () => void;
 }
 
-export default function JoinTree({
-  joinType,
-  refetchAllSchedules,
-}: JoinTreeProps) {
+export default function JoinTree({ joinType }: JoinTreeProps) {
   const [joinCode, setJoinCode] = useState("");
   const MC = React.useContext(ModalContext);
   const empActions = useEmployeeActions();
+  const queries = useDatabaseQueries();
 
   const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setJoinCode(event.target.value);
@@ -34,7 +32,7 @@ export default function JoinTree({
     empActions
       .join({ joinCode: joinCode })
       .then(() => {
-        refetchAllSchedules();
+        queries.refetchAllSchedules();
         MC.setModalOpen(false);
       })
       .catch(e => {

--- a/client/src/Navbar.tsx
+++ b/client/src/Navbar.tsx
@@ -35,6 +35,11 @@ import { useAuth } from "@/auth";
 import JoinTree from "./JoinTree";
 import { LeftDrawerContext } from "./Home";
 
+interface ModalContextType {
+  modalOpen: boolean;
+  setModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
 const CustomTooltip = styled(({ className, ...props }: TooltipProps) => (
   <Tooltip {...props} arrow classes={{ popper: className }} />
 ))(({ theme }) => ({
@@ -45,13 +50,15 @@ const CustomTooltip = styled(({ className, ...props }: TooltipProps) => (
     backgroundColor: theme.palette.common.black,
   },
 }));
-export const ModalContext = React.createContext();
+export const ModalContext = React.createContext<ModalContextType>({
+  modalOpen: false,
+  setModalOpen: () => {},
+});
 
 export default function Navbar() {
   const auth = useAuth();
   const navigate = useNavigate();
   const LDC = React.useContext(LeftDrawerContext);
-  const { refetchAllSchedules } = LDC;
   const handleDrawerToggle = () => {
     if (!LDC.isClosing) {
       LDC.setMobileOpen(!LDC.mobileOpen);
@@ -213,10 +220,7 @@ export default function Navbar() {
         </Drawer>
         <Dialog open={modalOpen} onClose={handleModalClose}>
           <ModalContext.Provider value={{ modalOpen, setModalOpen }}>
-            <JoinTree
-              joinType={joinType}
-              refetchAllSchedules={refetchAllSchedules}
-            />
+            <JoinTree joinType={joinType} />
           </ModalContext.Provider>
         </Dialog>
       </Box>

--- a/client/src/hooks/useDatabaseQueries.tsx
+++ b/client/src/hooks/useDatabaseQueries.tsx
@@ -1,0 +1,31 @@
+import { useMemo } from "react";
+import { useApi } from "@/client";
+
+export function useDatabaseQueries() {
+  const api = useApi();
+
+  const { data: scheduleData, refetch: refetchAllSchedules } = api.useQuery(
+    "get",
+    "/schedules",
+    {
+      headers: {
+        Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
+      },
+    },
+  );
+
+  const schedules = useMemo(
+    () =>
+      scheduleData?.map(schedule => ({
+        id: schedule.id,
+        name: schedule.name,
+        description: schedule.description,
+        state: schedule.state,
+        startTime: schedule.startTime,
+        endTime: schedule.endTime,
+      })),
+    [scheduleData],
+  );
+
+  return { schedules, refetchAllSchedules };
+}

--- a/client/src/hooks/useEmployeeActions.tsx
+++ b/client/src/hooks/useEmployeeActions.tsx
@@ -12,33 +12,37 @@ export function useEmployeeActions() {
     "/signups/{shiftId}",
   );
 
-  return {
-    async join({ joinCode }: { joinCode: string }): Promise<void> {
-      await joinShiftTree({
-        params: {
-          query: {
-            JoinCode: joinCode,
-          },
+  /*
+   * Changed structure to separately build functions and return them
+   * rather than creating them within the return statement
+   */
+  async function join({ joinCode }: { joinCode: string }): Promise<void> {
+    await joinShiftTree({
+      params: {
+        query: {
+          JoinCode: joinCode,
         },
-        headers: {
-          Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
-        },
-      });
-      console.log("Joined");
-    },
+      },
+      headers: {
+        Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
+      },
+    });
+    console.log("Joined");
+  }
 
-    async signup({ shiftId }: { shiftId: string }): Promise<void> {
-      await signupForShift({
-        params: {
-          path: {
-            shiftId,
-          },
+  async function signup({ shiftId }: { shiftId: string }): Promise<void> {
+    await signupForShift({
+      params: {
+        path: {
+          shiftId,
         },
-        headers: {
-          Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
-        },
-      });
-      console.log("Signed up for shift");
-    },
-  };
+      },
+      headers: {
+        Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
+      },
+    });
+    console.log("Signed up for shift");
+  }
+
+  return { join, signup };
 }

--- a/client/src/hooks/useEmployeeActions.tsx
+++ b/client/src/hooks/useEmployeeActions.tsx
@@ -1,13 +1,15 @@
 import { useApi } from "@/client";
-import { useAuth } from "@/auth";
 
 export function useEmployeeActions() {
   const api = useApi();
-  const auth = useAuth();
 
   const { mutateAsync: joinShiftTree } = api.useMutation(
     "put",
     "/joinShiftTree",
+  );
+  const { mutateAsync: signupForShift } = api.useMutation(
+    "post",
+    "/signups/{shiftId}",
   );
 
   return {
@@ -24,18 +26,7 @@ export function useEmployeeActions() {
       });
       console.log("Joined");
     },
-  };
-}
 
-export function useSignupActions() {
-  const api = useApi();
-
-  const { mutateAsync: signupForShift } = api.useMutation(
-    "post",
-    "/signups/{shiftId}",
-  );
-
-  return {
     async signup({ shiftId }: { shiftId: string }): Promise<void> {
       await signupForShift({
         params: {

--- a/server/api/openapi.yaml
+++ b/server/api/openapi.yaml
@@ -211,7 +211,7 @@ paths:
       responses:
         404:
           description: UUID does not have corresponding ShiftTree
-        200:
+        204:
           description: Request To Join Successful
         500:
           description: Unable to add User to Schedule

--- a/server/src/invites.ts
+++ b/server/src/invites.ts
@@ -100,7 +100,7 @@ export const joinShiftTree = async (req: Request, res: Response) => {
     const result = await pool.query(query);
     console.log(result);
 
-    res.status(200).send("User added to ShiftTree");
+    res.status(204).send("User added to ShiftTree");
   } catch (err) {
     console.error(err);
     res.status(500).send("Internal Server Error");


### PR DESCRIPTION
- Added a hook for API calls that aren't specific to employees/managers (think GETs on schedules)
- Made the Components use this instead
- Adjusted the yaml for OpenAPI (didn't regen types) to use a 204 as it kept giving errors for expecting json format
- Weird Error (?): An owner can join their own ShiftTree as employee, this shouldn't happen, but is outside the scope of the branch so I'll leave it as a later task