### PR TITLE
All non-algo aspects of recommended shifts

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -16,6 +16,7 @@
     "@emotion/styled": "^11.13.0",
     "@mui/icons-material": "^6.1.3",
     "@mui/material": "^6.1.3",
+    "@mui/system": "^6.1.8",
     "@mui/x-date-pickers": "^6.1.3",
     "@tanstack/react-query": "^5.59.13",
     "dayjs": "^1.11.13",

--- a/client/package.json
+++ b/client/package.json
@@ -14,9 +14,11 @@
   "dependencies": {
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
+    "@mui/base": "5.0.0-beta.62",
     "@mui/icons-material": "^6.1.3",
     "@mui/material": "^6.1.3",
     "@mui/system": "^6.1.8",
+    "@mui/utils": "^6.1.8",
     "@mui/x-date-pickers": "^6.1.3",
     "@tanstack/react-query": "^5.59.13",
     "dayjs": "^1.11.13",

--- a/client/pnpm-lock.yaml
+++ b/client/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@emotion/styled':
         specifier: ^11.13.0
         version: 11.13.0(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1)
+      '@mui/base':
+        specifier: 5.0.0-beta.62
+        version: 5.0.0-beta.62(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@mui/icons-material':
         specifier: ^6.1.3
         version: 6.1.3(@mui/material@6.1.3(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.11)(react@18.3.1)
@@ -23,6 +26,9 @@ importers:
       '@mui/system':
         specifier: ^6.1.8
         version: 6.1.8(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1)
+      '@mui/utils':
+        specifier: ^6.1.8
+        version: 6.1.8(@types/react@18.3.11)(react@18.3.1)
       '@mui/x-date-pickers':
         specifier: ^6.1.3
         version: 6.20.2(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1))(@mui/material@6.1.3(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mui/system@6.1.8(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(dayjs@1.11.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -485,8 +491,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
-  '@mui/base@5.0.0-beta.59':
-    resolution: {integrity: sha512-LQZ2907rPMut/2Lq6qSnyP+nqOHLO3buMv91m7SdLpqp/lXU5+8vUXcf5oOwTNis6hfSvYGSQJ493Q00OzxDmQ==}
+  '@mui/base@5.0.0-beta.62':
+    resolution: {integrity: sha512-TzJLCNlrMkSU4bTCdTT+TVUiGx4sjZLhH673UV6YN+rNNP8wJpkWfRSvjDB5HcbH2T0lUamnz643ZnV+8IiMjw==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@types/react': ^17.0.0 || ^18.0.0
@@ -591,26 +597,6 @@ packages:
     peerDependencies:
       '@types/react': ^17.0.0 || ^18.0.0
       react: ^17.0.0 || ^18.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@mui/utils@6.1.3':
-    resolution: {integrity: sha512-4JBpLkjprlKjN10DGb1aiy/ii9TKbQ601uSHtAmYFAS879QZgAD7vRnv/YBE4iBbc7NXzFgbQMCOFrupXWekIA==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
-      react: ^17.0.0 || ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@mui/utils@6.1.4':
-    resolution: {integrity: sha512-v0wXkyh3/Hpw48ivlNvgs4ZT6M8BIEAMdLgvct59rQBggYFhoAVKyliKDzdj37CnIlYau3DYIn7x5bHlRYFBow==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
-      react: ^17.0.0 || ^18.0.0 || ^19.0.0
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -2464,12 +2450,12 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
-  '@mui/base@5.0.0-beta.59(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@mui/base@5.0.0-beta.62(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.26.0
       '@floating-ui/react-dom': 2.1.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@mui/types': 7.2.18(@types/react@18.3.11)
-      '@mui/utils': 6.1.4(@types/react@18.3.11)(react@18.3.1)
+      '@mui/types': 7.2.19(@types/react@18.3.11)
+      '@mui/utils': 6.1.8(@types/react@18.3.11)(react@18.3.1)
       '@popperjs/core': 2.11.8
       clsx: 2.1.1
       prop-types: 15.8.1
@@ -2494,7 +2480,7 @@ snapshots:
       '@mui/core-downloads-tracker': 6.1.3
       '@mui/system': 6.1.8(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1)
       '@mui/types': 7.2.18(@types/react@18.3.11)
-      '@mui/utils': 6.1.3(@types/react@18.3.11)(react@18.3.1)
+      '@mui/utils': 6.1.8(@types/react@18.3.11)(react@18.3.1)
       '@popperjs/core': 2.11.8
       '@types/react-transition-group': 4.4.11
       clsx: 2.1.1
@@ -2567,30 +2553,6 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.11
 
-  '@mui/utils@6.1.3(@types/react@18.3.11)(react@18.3.1)':
-    dependencies:
-      '@babel/runtime': 7.25.7
-      '@mui/types': 7.2.18(@types/react@18.3.11)
-      '@types/prop-types': 15.7.13
-      clsx: 2.1.1
-      prop-types: 15.8.1
-      react: 18.3.1
-      react-is: 18.3.1
-    optionalDependencies:
-      '@types/react': 18.3.11
-
-  '@mui/utils@6.1.4(@types/react@18.3.11)(react@18.3.1)':
-    dependencies:
-      '@babel/runtime': 7.25.7
-      '@mui/types': 7.2.18(@types/react@18.3.11)
-      '@types/prop-types': 15.7.13
-      clsx: 2.1.1
-      prop-types: 15.8.1
-      react: 18.3.1
-      react-is: 18.3.1
-    optionalDependencies:
-      '@types/react': 18.3.11
-
   '@mui/utils@6.1.8(@types/react@18.3.11)(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.26.0
@@ -2606,7 +2568,7 @@ snapshots:
   '@mui/x-date-pickers@6.20.2(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1))(@mui/material@6.1.3(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mui/system@6.1.8(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(dayjs@1.11.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.25.7
-      '@mui/base': 5.0.0-beta.59(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@mui/base': 5.0.0-beta.62(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@mui/material': 6.1.3(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@mui/system': 6.1.8(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1)
       '@mui/utils': 5.16.6(@types/react@18.3.11)(react@18.3.1)
@@ -2994,7 +2956,7 @@ snapshots:
 
   babel-plugin-macros@3.1.0:
     dependencies:
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.26.0
       cosmiconfig: 7.1.0
       resolve: 1.22.8
 
@@ -3142,7 +3104,7 @@ snapshots:
 
   dom-helpers@5.2.1:
     dependencies:
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.26.0
       csstype: 3.1.3
 
   electron-to-chromium@1.5.36: {}

--- a/client/pnpm-lock.yaml
+++ b/client/pnpm-lock.yaml
@@ -20,9 +20,12 @@ importers:
       '@mui/material':
         specifier: ^6.1.3
         version: 6.1.3(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@mui/system':
+        specifier: ^6.1.8
+        version: 6.1.8(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1)
       '@mui/x-date-pickers':
         specifier: ^6.1.3
-        version: 6.20.2(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1))(@mui/material@6.1.3(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mui/system@6.1.3(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(dayjs@1.11.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 6.20.2(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1))(@mui/material@6.1.3(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mui/system@6.1.8(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(dayjs@1.11.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tanstack/react-query':
         specifier: ^5.59.13
         version: 5.59.13(react@18.3.1)
@@ -189,6 +192,10 @@ packages:
 
   '@babel/runtime@7.25.7':
     resolution: {integrity: sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/runtime@7.26.0':
+    resolution: {integrity: sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/template@7.25.7':
@@ -523,8 +530,8 @@ packages:
       '@types/react':
         optional: true
 
-  '@mui/private-theming@6.1.3':
-    resolution: {integrity: sha512-XK5OYCM0x7gxWb/WBEySstBmn+dE3YKX7U7jeBRLm6vHU5fGUd7GiJWRirpivHjOK9mRH6E1MPIVd+ze5vguKQ==}
+  '@mui/private-theming@6.1.8':
+    resolution: {integrity: sha512-TuKl7msynCNCVvhX3c0ef1sF0Qb3VHcPs8XOGB/8bdOGBr/ynmIG1yTMjZeiFQXk8yN9fzK/FDEKMFxILNn3wg==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -533,8 +540,8 @@ packages:
       '@types/react':
         optional: true
 
-  '@mui/styled-engine@6.1.3':
-    resolution: {integrity: sha512-i4yh9m+eMZE3cNERpDhVr6Wn73Yz6C7MH0eE2zZvw8d7EFkIJlCQNZd1xxGZqarD2DDq2qWHcjIOucWGhxACtA==}
+  '@mui/styled-engine@6.1.8':
+    resolution: {integrity: sha512-ZvEoT0U2nPLSLI+B4by4cVjaZnPT2f20f4JUPkyHdwLv65ZzuoHiTlwyhqX1Ch63p8bcJzKTHQVGisEoMK6PGA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@emotion/react': ^11.4.1
@@ -546,8 +553,8 @@ packages:
       '@emotion/styled':
         optional: true
 
-  '@mui/system@6.1.3':
-    resolution: {integrity: sha512-ILaD9UsLTBLjMcep3OumJMXh1PYr7aqnkHm/L47bH46+YmSL1zWAX6tWG8swEQROzW2GvYluEMp5FreoxOOC6w==}
+  '@mui/system@6.1.8':
+    resolution: {integrity: sha512-i1kLfQoWxzFpXTBQIuPoA3xKnAnP3en4I2T8xIolovSolGQX5k8vGjw1JaydQS40td++cFsgCdEU458HDNTGUA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@emotion/react': ^11.5.0
@@ -564,6 +571,14 @@ packages:
 
   '@mui/types@7.2.18':
     resolution: {integrity: sha512-uvK9dWeyCJl/3ocVnTOS6nlji/Knj8/tVqVX03UVTpdmTJYu/s4jtDd9Kvv0nRGE0CUSNW1UYAci7PYypjealg==}
+    peerDependencies:
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@mui/types@7.2.19':
+    resolution: {integrity: sha512-6XpZEM/Q3epK9RN8ENoXuygnqUQxE+siN/6rGRi2iwJPgBUR25mphYQ9ZI87plGh58YoZ5pp40bFvKYOCDJ3tA==}
     peerDependencies:
       '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
     peerDependenciesMeta:
@@ -592,6 +607,16 @@ packages:
 
   '@mui/utils@6.1.4':
     resolution: {integrity: sha512-v0wXkyh3/Hpw48ivlNvgs4ZT6M8BIEAMdLgvct59rQBggYFhoAVKyliKDzdj37CnIlYau3DYIn7x5bHlRYFBow==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@mui/utils@6.1.8':
+    resolution: {integrity: sha512-O2DWb1kz8hiANVcR7Z4gOB3SvPPsSQGUmStpyBDzde6dJIfBzgV9PbEQOBZd3EBsd1pB+Uv1z5LAJAbymmawrA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -2175,6 +2200,10 @@ snapshots:
     dependencies:
       regenerator-runtime: 0.14.1
 
+  '@babel/runtime@7.26.0':
+    dependencies:
+      regenerator-runtime: 0.14.1
+
   '@babel/template@7.25.7':
     dependencies:
       '@babel/code-frame': 7.25.7
@@ -2463,7 +2492,7 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.25.7
       '@mui/core-downloads-tracker': 6.1.3
-      '@mui/system': 6.1.3(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1)
+      '@mui/system': 6.1.8(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1)
       '@mui/types': 7.2.18(@types/react@18.3.11)
       '@mui/utils': 6.1.3(@types/react@18.3.11)(react@18.3.1)
       '@popperjs/core': 2.11.8
@@ -2480,18 +2509,18 @@ snapshots:
       '@emotion/styled': 11.13.0(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1)
       '@types/react': 18.3.11
 
-  '@mui/private-theming@6.1.3(@types/react@18.3.11)(react@18.3.1)':
+  '@mui/private-theming@6.1.8(@types/react@18.3.11)(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.25.7
-      '@mui/utils': 6.1.3(@types/react@18.3.11)(react@18.3.1)
+      '@babel/runtime': 7.26.0
+      '@mui/utils': 6.1.8(@types/react@18.3.11)(react@18.3.1)
       prop-types: 15.8.1
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.11
 
-  '@mui/styled-engine@6.1.3(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1))(react@18.3.1)':
+  '@mui/styled-engine@6.1.8(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.26.0
       '@emotion/cache': 11.13.1
       '@emotion/serialize': 1.3.2
       '@emotion/sheet': 1.4.0
@@ -2502,13 +2531,13 @@ snapshots:
       '@emotion/react': 11.13.3(@types/react@18.3.11)(react@18.3.1)
       '@emotion/styled': 11.13.0(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1)
 
-  '@mui/system@6.1.3(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1)':
+  '@mui/system@6.1.8(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.25.7
-      '@mui/private-theming': 6.1.3(@types/react@18.3.11)(react@18.3.1)
-      '@mui/styled-engine': 6.1.3(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1))(react@18.3.1)
-      '@mui/types': 7.2.18(@types/react@18.3.11)
-      '@mui/utils': 6.1.3(@types/react@18.3.11)(react@18.3.1)
+      '@babel/runtime': 7.26.0
+      '@mui/private-theming': 6.1.8(@types/react@18.3.11)(react@18.3.1)
+      '@mui/styled-engine': 6.1.8(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1))(react@18.3.1)
+      '@mui/types': 7.2.19(@types/react@18.3.11)
+      '@mui/utils': 6.1.8(@types/react@18.3.11)(react@18.3.1)
       clsx: 2.1.1
       csstype: 3.1.3
       prop-types: 15.8.1
@@ -2519,6 +2548,10 @@ snapshots:
       '@types/react': 18.3.11
 
   '@mui/types@7.2.18(@types/react@18.3.11)':
+    optionalDependencies:
+      '@types/react': 18.3.11
+
+  '@mui/types@7.2.19(@types/react@18.3.11)':
     optionalDependencies:
       '@types/react': 18.3.11
 
@@ -2558,12 +2591,24 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.11
 
-  '@mui/x-date-pickers@6.20.2(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1))(@mui/material@6.1.3(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mui/system@6.1.3(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(dayjs@1.11.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@mui/utils@6.1.8(@types/react@18.3.11)(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.26.0
+      '@mui/types': 7.2.19(@types/react@18.3.11)
+      '@types/prop-types': 15.7.13
+      clsx: 2.1.1
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-is: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.11
+
+  '@mui/x-date-pickers@6.20.2(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1))(@mui/material@6.1.3(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mui/system@6.1.8(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(dayjs@1.11.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.25.7
       '@mui/base': 5.0.0-beta.59(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@mui/material': 6.1.3(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@mui/system': 6.1.3(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1)
+      '@mui/system': 6.1.8(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1)
       '@mui/utils': 5.16.6(@types/react@18.3.11)(react@18.3.1)
       '@types/react-transition-group': 4.4.11
       clsx: 2.1.1

--- a/client/src/customComponents/CompactNumberInput.tsx
+++ b/client/src/customComponents/CompactNumberInput.tsx
@@ -63,7 +63,7 @@ export default function UseNumberInputCompact({
 }: CompactNumberInputProps) {
   return (
     <Layout>
-      <Pre>Suggested Shifts: {suggestedShifts ?? " "}</Pre>
+      <Pre>Recommended Shifts: {suggestedShifts ?? " "}</Pre>
 
       <CompactNumberInput
         aria-label="Compact Suggested Shifts"

--- a/client/src/customComponents/CompactNumberInput.tsx
+++ b/client/src/customComponents/CompactNumberInput.tsx
@@ -1,0 +1,152 @@
+import * as React from "react";
+import {
+  unstable_useNumberInput as useNumberInput,
+  UseNumberInputParameters,
+} from "@mui/base/unstable_useNumberInput";
+import { styled } from "@mui/system";
+import { unstable_useForkRef as useForkRef } from "@mui/utils";
+import ArrowDropUpRoundedIcon from "@mui/icons-material/ArrowDropUpRounded";
+import ArrowDropDownRoundedIcon from "@mui/icons-material/ArrowDropDownRounded";
+
+const CompactNumberInput = React.forwardRef(function CompactNumberInput(
+  props: Omit<
+    React.InputHTMLAttributes<HTMLInputElement>,
+    "onChange" | "value"
+  > &
+    UseNumberInputParameters,
+  ref: React.ForwardedRef<HTMLInputElement>,
+) {
+  const {
+    getRootProps,
+    getInputProps,
+    getIncrementButtonProps,
+    getDecrementButtonProps,
+  } = useNumberInput(props);
+
+  const inputProps = getInputProps();
+
+  inputProps.ref = useForkRef(inputProps.ref, ref);
+
+  return (
+    <StyledInputRoot {...getRootProps()}>
+      <StyledStepperButton className="increment" {...getIncrementButtonProps()}>
+        <ArrowDropUpRoundedIcon />
+      </StyledStepperButton>
+      <StyledStepperButton className="decrement" {...getDecrementButtonProps()}>
+        <ArrowDropDownRoundedIcon />
+      </StyledStepperButton>
+      <HiddenInput {...inputProps} />
+    </StyledInputRoot>
+  );
+});
+
+export default function UseNumberInputCompact() {
+  const [value, setValue] = React.useState<number | null>(null);
+
+  return (
+    <Layout>
+      <CompactNumberInput
+        aria-label="Compact Suggested Shifts"
+        placeholder="Input Suggested Shifts"
+        readOnly
+        value={value}
+        onChange={(_, val) => setValue(val)}
+      />
+
+      <Pre>Suggested Shifts: {value ?? " "}</Pre>
+    </Layout>
+  );
+}
+
+const blue = {
+  100: "#DAECFF",
+  200: "#80BFFF",
+  400: "#3399FF",
+  500: "#007FFF",
+  600: "#0072E5",
+  700: "#0059B2",
+};
+
+const grey = {
+  50: "#F3F6F9",
+  100: "#E5EAF2",
+  200: "#DAE2ED",
+  300: "#C7D0DD",
+  400: "#B0B8C4",
+  500: "#9DA8B7",
+  600: "#6B7A90",
+  700: "#434D5B",
+  800: "#303740",
+  900: "#1C2025",
+};
+
+const StyledInputRoot = styled("div")(
+  ({ theme }) => `
+    display: grid;
+    grid-template-columns: 2rem;
+    grid-template-rows: 2rem 2rem;
+    grid-template-areas:
+      "increment"
+      "decrement";
+    row-gap: 1px;
+    overflow: auto;
+    border-radius: 8px;
+    border-style: solid;
+    border-width: 1px;
+    color: ${theme.palette.mode === "dark" ? grey[300] : grey[900]};
+    border-color: ${theme.palette.mode === "dark" ? grey[800] : grey[200]};
+    box-shadow: 0px 2px 4px ${
+      theme.palette.mode === "dark" ? "rgba(0,0,0, 0.5)" : "rgba(0,0,0, 0.05)"
+    };
+  `,
+);
+
+const HiddenInput = styled("input")`
+  visibility: hidden;
+  position: absolute;
+`;
+
+const StyledStepperButton = styled("button")(
+  ({ theme }) => `
+  display: flex;
+  flex-flow: nowrap;
+  justify-content: center;
+  align-items: center;
+  font-size: 0.875rem;
+  box-sizing: border-box;
+  border: 0;
+  padding: 0;
+  color: inherit;
+  background: ${theme.palette.mode === "dark" ? grey[900] : grey[50]};
+
+  &:hover {
+    cursor: pointer;
+    background: ${theme.palette.mode === "dark" ? blue[700] : blue[500]};
+    color: ${grey[50]};
+  }
+
+  &:focus-visible {
+    outline: 0;
+    box-shadow: 0 0 0 3px ${theme.palette.mode === "dark" ? blue[700] : blue[200]};
+  }
+
+  &.increment {
+    grid-area: increment;
+  }
+
+  &.decrement {
+    grid-area: decrement;
+  }
+`,
+);
+
+const Layout = styled("div")`
+  display: flex;
+  flex-flow: row nowrap;
+  align-items: center;
+  column-gap: 1rem;
+`;
+
+const Pre = styled("pre")`
+  font-size: 0.75rem;
+`;

--- a/client/src/customComponents/CompactNumberInput.tsx
+++ b/client/src/customComponents/CompactNumberInput.tsx
@@ -1,59 +1,75 @@
 import * as React from "react";
-import {
-  unstable_useNumberInput as useNumberInput,
-  UseNumberInputParameters,
-} from "@mui/base/unstable_useNumberInput";
 import { styled } from "@mui/system";
-import { unstable_useForkRef as useForkRef } from "@mui/utils";
 import ArrowDropUpRoundedIcon from "@mui/icons-material/ArrowDropUpRounded";
 import ArrowDropDownRoundedIcon from "@mui/icons-material/ArrowDropDownRounded";
 
+interface CompactNumberInputProps {
+  suggestedShifts: number | null;
+  onChange: (newValue: number | null) => void;
+}
+
 const CompactNumberInput = React.forwardRef(function CompactNumberInput(
-  props: Omit<
-    React.InputHTMLAttributes<HTMLInputElement>,
-    "onChange" | "value"
-  > &
-    UseNumberInputParameters,
+  { suggestedShifts, onChange, ...props }: CompactNumberInputProps,
   ref: React.ForwardedRef<HTMLInputElement>,
 ) {
-  const {
-    getRootProps,
-    getInputProps,
-    getIncrementButtonProps,
-    getDecrementButtonProps,
-  } = useNumberInput(props);
+  const handleIncrement = () => {
+    if (suggestedShifts !== null) {
+      onChange(suggestedShifts + 1);
+    }
+  };
 
-  const inputProps = getInputProps();
+  const handleDecrement = () => {
+    if (suggestedShifts !== null) {
+      if (suggestedShifts > 0) {
+        onChange(suggestedShifts - 1);
+      } else {
+        onChange(suggestedShifts);
+      }
+    }
+  };
 
-  inputProps.ref = useForkRef(inputProps.ref, ref);
+  const handleHiddenInputChange = (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    const newValue = Number(event.target.value);
+    if (!isNaN(newValue)) {
+      onChange(newValue);
+    } else {
+      onChange(null);
+    }
+  };
 
   return (
-    <StyledInputRoot {...getRootProps()}>
-      <StyledStepperButton className="increment" {...getIncrementButtonProps()}>
+    <StyledInputRoot>
+      <StyledStepperButton className="increment" onClick={handleIncrement}>
         <ArrowDropUpRoundedIcon />
       </StyledStepperButton>
-      <StyledStepperButton className="decrement" {...getDecrementButtonProps()}>
+      <StyledStepperButton className="decrement" onClick={handleDecrement}>
         <ArrowDropDownRoundedIcon />
       </StyledStepperButton>
-      <HiddenInput {...inputProps} />
+      <HiddenInput
+        {...props}
+        ref={ref}
+        value={suggestedShifts ?? ""}
+        onChange={handleHiddenInputChange}
+      />
     </StyledInputRoot>
   );
 });
 
-export default function UseNumberInputCompact() {
-  const [value, setValue] = React.useState<number | null>(null);
-
+export default function UseNumberInputCompact({
+  suggestedShifts,
+  onChange,
+}: CompactNumberInputProps) {
   return (
     <Layout>
+      <Pre>Suggested Shifts: {suggestedShifts ?? " "}</Pre>
+
       <CompactNumberInput
         aria-label="Compact Suggested Shifts"
-        placeholder="Input Suggested Shifts"
-        readOnly
-        value={value}
-        onChange={(_, val) => setValue(val)}
+        suggestedShifts={suggestedShifts}
+        onChange={onChange}
       />
-
-      <Pre>Suggested Shifts: {value ?? " "}</Pre>
     </Layout>
   );
 }
@@ -83,13 +99,13 @@ const grey = {
 const StyledInputRoot = styled("div")(
   ({ theme }) => `
     display: grid;
-    grid-template-columns: 2rem;
-    grid-template-rows: 2rem 2rem;
+    grid-template-columns: 1.2rem;
+    grid-template-rows: 1.2rem 1.2rem;
     grid-template-areas:
       "increment"
       "decrement";
-    row-gap: 1px;
-    overflow: auto;
+    row-gap: 0.5px;
+    overflow: hidden;
     border-radius: 8px;
     border-style: solid;
     border-width: 1px;
@@ -116,6 +132,8 @@ const StyledStepperButton = styled("button")(
   box-sizing: border-box;
   border: 0;
   padding: 0;
+  width: 1.2rem;
+  height: 1.2rem;
   color: inherit;
   background: ${theme.palette.mode === "dark" ? grey[900] : grey[50]};
 
@@ -144,7 +162,7 @@ const Layout = styled("div")`
   display: flex;
   flex-flow: row nowrap;
   align-items: center;
-  column-gap: 1rem;
+  column-gap: 0.65rem;
 `;
 
 const Pre = styled("pre")`

--- a/client/src/generated/v1.d.ts
+++ b/client/src/generated/v1.d.ts
@@ -1388,6 +1388,7 @@ export interface components {
             displayName: string;
             email: string;
             profileImageUrl?: string;
+            suggestedShifts?: number;
         };
         UUID: string;
         ScheduleInfo: components["schemas"]["ScheduleInfoPreview"];

--- a/client/src/generated/v1.d.ts
+++ b/client/src/generated/v1.d.ts
@@ -778,16 +778,12 @@ export interface paths {
                 };
             };
             responses: {
-                /** @description Successful */
-                200: {
+                /** @description Update of user's recommended shifts successful */
+                204: {
                     headers: {
                         [name: string]: unknown;
                     };
-                    content: {
-                        "application/json": {
-                            newRecommendedShifts?: string;
-                        };
-                    };
+                    content?: never;
                 };
                 /** @description User does not have permission to modify recommended shifts */
                 403: {

--- a/client/src/generated/v1.d.ts
+++ b/client/src/generated/v1.d.ts
@@ -748,6 +748,73 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/schedules/{scheduleId}/recommended-shifts": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Update the given user's recommended shifts as set by manager */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    scheduleId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        /** @description User to update recommended shifts for */
+                        userId?: string;
+                        /** @description New recommended number of shifts for specified user */
+                        recommendedNumShifts?: number;
+                    };
+                };
+            };
+            responses: {
+                /** @description Successful */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            newRecommendedShifts?: string;
+                        };
+                    };
+                };
+                /** @description User does not have permission to modify recommended shifts */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+                /** @description User with given userId does not exist or cannot be modified */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/schedules/{scheduleId}/shifts": {
         parameters: {
             query?: never;

--- a/client/src/hooks/useManagerActions.tsx
+++ b/client/src/hooks/useManagerActions.tsx
@@ -11,6 +11,10 @@ export function useManagerActions(shiftTreeId: string) {
     "post",
     "/autoschedule/{scheduleId}",
   );
+  const { mutateAsync: updateRecommendedShifts } = api.useMutation(
+    "post",
+    "/schedules/{scheduleId}/recommended-shifts",
+  );
   /*
    * Takes in a shiftTreeId and generates a new code
    * Function returns the code to be used after generating
@@ -63,7 +67,34 @@ export function useManagerActions(shiftTreeId: string) {
     },
   });
 
+  async function updateRecommendedNumShifts({
+    scheduleId,
+    targetUserId,
+    numShifts,
+  }: {
+    scheduleId: string;
+    targetUserId: string;
+    numShifts: number;
+  }): Promise<void> {
+    await updateRecommendedShifts({
+      params: {
+        path: {
+          scheduleId: scheduleId,
+        },
+      },
+      body: {
+        userId: targetUserId,
+        recommendedNumShifts: numShifts,
+      },
+    });
+  }
+
   const existingCode = data?.code;
 
-  return { generate, existingCode, triggerAutoSchedule };
+  return {
+    generate,
+    existingCode,
+    triggerAutoSchedule,
+    updateRecommendedNumShifts,
+  };
 }

--- a/client/src/schedule/EditMembersTab.tsx
+++ b/client/src/schedule/EditMembersTab.tsx
@@ -19,6 +19,8 @@ import EditMembersDrawer from "./EditMembersDrawer";
 import { useApi } from "@/client";
 import dayjs from "dayjs";
 import { useManagerActions } from "@/hooks/useManagerActions";
+import CompactNumInput from "@/customComponents/CompactNumInput";
+import CompactNumberInput from "@/customComponents/CompactNumberInput";
 
 interface EditMembersTabProps {
   scheduleId: string;
@@ -42,6 +44,7 @@ export default function EditMembersTab(props: EditMembersTabProps) {
 
   // TODO: Add the base url as an environment variable so it can be set during build
   const [inviteCode, setInviteCode] = useState<string>("");
+
   useEffect(() => {
     if (managerActions.existingCode) {
       setInviteCode(managerActions.existingCode);
@@ -143,6 +146,15 @@ export default function EditMembersTab(props: EditMembersTabProps) {
             )}
             onKick={() => setUserToKick(member)}
           />
+          <Box
+            sx={{
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "flex-start",
+            }}
+          >
+            <CompactNumberInput />
+          </Box>
         </Fragment>
       ))}
     </Box>
@@ -223,6 +235,7 @@ function MemberItem(props: MemberItemProps) {
             <br></br>
           </Typography>
           <Divider sx={{ borderColor: "blue" }} />
+
           {drawerOpen && (
             <ShiftDisplay userId={props.userId} scheduleId={props.scheduleId} />
           )}

--- a/client/src/schedule/EditMembersTab.tsx
+++ b/client/src/schedule/EditMembersTab.tsx
@@ -21,6 +21,7 @@ import { useApi } from "@/client";
 import { useManagerActions } from "@/hooks/useManagerActions";
 import EditMembersDrawer from "./EditMembersDrawer";
 import CompactNumberInput from "@/customComponents/CompactNumberInput";
+import { palette } from "@mui/system";
 
 interface EditMembersTabProps {
   scheduleId: string;
@@ -90,12 +91,30 @@ export default function EditMembersTab(props: EditMembersTabProps) {
     [key: string]: number;
   }>({});
 
+  useEffect(() => {
+    if (membersData) {
+      const suggestedShiftsFromDB: { [key: string]: number } = {};
+      for (const member of membersData) {
+        suggestedShiftsFromDB[member.id] = member.suggestedShifts ?? -100;
+      }
+      setSuggestedShifts(suggestedShiftsFromDB);
+    }
+  }, [membersData]);
+
   const handleSuggestedChange = (userId: string, value: number | null) => {
     const checkValue = value ?? 0;
     setSuggestedShifts(prevState => ({
       ...prevState,
       [userId]: checkValue,
     }));
+  };
+
+  const handleSuggestionsSubmit = async () => {
+    for (const [userId, numShifts] of Object.entries(suggestedShifts)) {
+      // Will replace with the hook to the PUT/POST endpoint
+      console.log(userId, ": ", numShifts);
+    }
+    // Add snackbar here
   };
 
   return (
@@ -173,6 +192,23 @@ export default function EditMembersTab(props: EditMembersTabProps) {
           </Box>
         </Fragment>
       ))}
+      <Divider />
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "flex-start",
+        }}
+      >
+        <Typography variant="h5">Confirm Options:</Typography>
+        <Button
+          variant="contained"
+          onClick={handleSuggestionsSubmit}
+          sx={{ backgroundColor: theme => theme.palette.info.light }}
+        >
+          Submit Suggested Shifts
+        </Button>
+      </Box>
     </Box>
   );
 }

--- a/client/src/schedule/EditMembersTab.tsx
+++ b/client/src/schedule/EditMembersTab.tsx
@@ -19,9 +19,9 @@ import dayjs from "dayjs";
 
 import { useApi } from "@/client";
 import { useManagerActions } from "@/hooks/useManagerActions";
+import { useNotifier } from "@/notifier";
 import EditMembersDrawer from "./EditMembersDrawer";
 import CompactNumberInput from "@/customComponents/CompactNumberInput";
-import { palette } from "@mui/system";
 
 interface EditMembersTabProps {
   scheduleId: string;
@@ -30,6 +30,7 @@ interface EditMembersTabProps {
 export default function EditMembersTab(props: EditMembersTabProps) {
   const api = useApi();
   const managerActions = useManagerActions(props.scheduleId);
+  const notifier = useNotifier();
 
   const { data: scheduleData } = api.useQuery(
     "get",
@@ -111,10 +112,13 @@ export default function EditMembersTab(props: EditMembersTabProps) {
 
   const handleSuggestionsSubmit = async () => {
     for (const [userId, numShifts] of Object.entries(suggestedShifts)) {
-      // Will replace with the hook to the PUT/POST endpoint
-      console.log(userId, ": ", numShifts);
+      await managerActions.updateRecommendedNumShifts({
+        scheduleId: props.scheduleId,
+        targetUserId: userId,
+        numShifts: numShifts,
+      });
     }
-    // Add snackbar here
+    notifier.message("Updated Recommended Shifts for Employees");
   };
 
   return (

--- a/client/src/schedule/EditMembersTab.tsx
+++ b/client/src/schedule/EditMembersTab.tsx
@@ -92,6 +92,10 @@ export default function EditMembersTab(props: EditMembersTabProps) {
     [key: string]: number;
   }>({});
 
+  const [lastSubmittedSuggestions, setLastSubmittedSuggestions] = useState<{
+    [key: string]: number;
+  }>({});
+
   useEffect(() => {
     if (membersData) {
       const suggestedShiftsFromDB: { [key: string]: number } = {};
@@ -99,6 +103,7 @@ export default function EditMembersTab(props: EditMembersTabProps) {
         suggestedShiftsFromDB[member.id] = member.suggestedShifts ?? -100;
       }
       setSuggestedShifts(suggestedShiftsFromDB);
+      setLastSubmittedSuggestions(suggestedShiftsFromDB);
     }
   }, [membersData]);
 
@@ -119,6 +124,14 @@ export default function EditMembersTab(props: EditMembersTabProps) {
       });
     }
     notifier.message("Updated Recommended Shifts for Employees");
+    setLastSubmittedSuggestions(suggestedShifts);
+  };
+
+  const unsubmittedRecommendationChanges = () => {
+    return (
+      JSON.stringify(suggestedShifts) !==
+      JSON.stringify(lastSubmittedSuggestions)
+    );
   };
 
   return (
@@ -208,7 +221,16 @@ export default function EditMembersTab(props: EditMembersTabProps) {
         <Button
           variant="contained"
           onClick={handleSuggestionsSubmit}
-          sx={{ backgroundColor: theme => theme.palette.info.light }}
+          disabled={!unsubmittedRecommendationChanges()}
+          sx={{
+            backgroundColor: theme => theme.palette.info.light,
+            "&.Mui-disabled": {
+              opacity: 0.4,
+              backgroundColor: theme =>
+                theme.palette.info.light + " !important",
+              color: "#FFFFFF",
+            },
+          }}
         >
           Submit Suggested Shifts
         </Button>

--- a/client/src/schedule/EditMembersTab.tsx
+++ b/client/src/schedule/EditMembersTab.tsx
@@ -15,11 +15,11 @@ import {
 } from "@mui/material";
 import { Link as RouterLink } from "react-router-dom";
 import { Fragment, useState, useEffect } from "react";
-import EditMembersDrawer from "./EditMembersDrawer";
-import { useApi } from "@/client";
 import dayjs from "dayjs";
+
+import { useApi } from "@/client";
 import { useManagerActions } from "@/hooks/useManagerActions";
-import CompactNumInput from "@/customComponents/CompactNumInput";
+import EditMembersDrawer from "./EditMembersDrawer";
 import CompactNumberInput from "@/customComponents/CompactNumberInput";
 
 interface EditMembersTabProps {
@@ -85,6 +85,18 @@ export default function EditMembersTab(props: EditMembersTabProps) {
       },
     });
   }
+
+  const [suggestedShifts, setSuggestedShifts] = useState<{
+    [key: string]: number;
+  }>({});
+
+  const handleSuggestedChange = (userId: string, value: number | null) => {
+    const checkValue = value ?? 0;
+    setSuggestedShifts(prevState => ({
+      ...prevState,
+      [userId]: checkValue,
+    }));
+  };
 
   return (
     <Box
@@ -153,7 +165,11 @@ export default function EditMembersTab(props: EditMembersTabProps) {
               alignItems: "flex-start",
             }}
           >
-            <CompactNumberInput />
+            <Typography variant="body2">User Options:</Typography>
+            <CompactNumberInput
+              suggestedShifts={suggestedShifts[member.id] ?? 0}
+              onChange={newValue => handleSuggestedChange(member.id, newValue)}
+            />
           </Box>
         </Fragment>
       ))}

--- a/scheduling/scheduling/models.py
+++ b/scheduling/scheduling/models.py
@@ -24,6 +24,7 @@ class Shift(BaseModel):
 
 class ScheduleRequest(BaseModel):
     shifts: Sequence[Shift]
+    shift_offsets: Mapping[UserId, int]
     seed: int | None = None
 
 

--- a/scheduling/scheduling/schedule.py
+++ b/scheduling/scheduling/schedule.py
@@ -45,7 +45,8 @@ class Config(BaseModel):
             },
             employees={
                 signup.user_id: Employee(
-                    requests={shift.id: Request(weight=signup.weight)}
+                    requests={shift.id: Request(weight=signup.weight)},
+                    min_shifts=request.shift_offsets.get(signup.user_id),
                 )
                 for shift in request.shifts
                 for signup in shift.signups

--- a/scheduling/tests/pass_fail/infeasable_overlapping_suggested_shifts.fail.toml
+++ b/scheduling/tests/pass_fail/infeasable_overlapping_suggested_shifts.fail.toml
@@ -1,0 +1,23 @@
+[shifts.a1]
+start_time = "2024-12-01 08:00"
+end_time = "2024-12-01 16:00"
+
+
+[shifts.a2]
+start_time = "2024-12-01 08:00"
+end_time = "2024-12-01 16:00"
+
+[shifts.b1]
+start_time = "2024-12-04 08:00"
+end_time = "2024-12-04 16:00"
+
+
+[shifts.b2]
+start_time = "2024-12-04 08:00"
+end_time = "2024-12-04 16:00"
+
+[employees.Foo]
+min_shifts = 1
+
+[employees.Bar]
+min_shifts = 3

--- a/scheduling/tests/pass_fail/simple_suggested_shifts.pass.toml
+++ b/scheduling/tests/pass_fail/simple_suggested_shifts.pass.toml
@@ -1,0 +1,23 @@
+[shifts.a1]
+start_time = "2024-12-01 08:00"
+end_time = "2024-12-01 16:00"
+
+
+[shifts.a2]
+start_time = "2024-12-02 08:00"
+end_time = "2024-12-02 16:00"
+
+[shifts.b1]
+start_time = "2024-12-04 08:00"
+end_time = "2024-12-04 16:00"
+
+
+[shifts.b2]
+start_time = "2024-12-05 08:00"
+end_time = "2024-12-05 16:00"
+
+[employees.Foo]
+min_shifts = 1
+
+[employees.Bar]
+min_shifts = 3

--- a/server/api/openapi.yaml
+++ b/server/api/openapi.yaml
@@ -474,6 +474,53 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
 
+  /schedules/{scheduleId}/recommended-shifts:
+    post:
+      security:
+        - Bearer: []
+      summary: Update the given user's recommended shifts as set by manager
+      parameters:
+        - name: scheduleId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                userId:
+                  description: User to update recommended shifts for
+                  type: string
+                recommendedNumShifts:
+                  description: New recommended number of shifts for specified user
+                  type: number
+      responses:
+        200:
+          description: Successful
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  newRecommendedShifts:
+                    type: string
+        403:
+          description: User does not have permission to modify recommended shifts
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        404:
+          description: User with given userId does not exist or cannot be modified
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
   /schedules/{scheduleId}/shifts:
     get:
       security:

--- a/server/api/openapi.yaml
+++ b/server/api/openapi.yaml
@@ -499,15 +499,8 @@ paths:
                   description: New recommended number of shifts for specified user
                   type: number
       responses:
-        200:
-          description: Successful
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  newRecommendedShifts:
-                    type: string
+        204:
+          description: Update of user's recommended shifts successful
         403:
           description: User does not have permission to modify recommended shifts
           content:

--- a/server/api/openapi.yaml
+++ b/server/api/openapi.yaml
@@ -942,6 +942,8 @@ components:
           type: string
         profileImageUrl:
           type: string
+        suggestedShifts:
+          type: integer
 
     UUID:
       type: string

--- a/server/db/0.schema.sql
+++ b/server/db/0.schema.sql
@@ -182,14 +182,14 @@ SELECT
     CASE
         WHEN COALESCE(member_count.total_members, 0) = 0 THEN 0
         ELSE FLOOR(COALESCE(shift_count.total_shifts, 0) * 1.0 / COALESCE(member_count.total_members, 1))
-    END AS min_shifts_per_employee,
+    END AS base_min_per_employee,
     CASE
         WHEN COALESCE(member_count.total_members, 0) = 0 THEN 0
         WHEN COALESCE(shift_count.total_shifts, 0) % COALESCE(member_count.total_members, 1) = 0 THEN
             FLOOR(COALESCE(shift_count.total_shifts, 0) * 1.0 / COALESCE(member_count.total_members, 1))
         ELSE
             FLOOR(COALESCE(shift_count.total_shifts, 0) * 1.0 / COALESCE(member_count.total_members, 1)) + 1
-    END AS max_shifts_per_employee
+    END AS base_max_per_employee
 FROM schedule AS s
 LEFT JOIN member_count ON s.id = member_count.schedule_id
 LEFT JOIN shift_count ON s.id = shift_count.schedule_id;

--- a/server/db/0.schema.sql
+++ b/server/db/0.schema.sql
@@ -154,3 +154,31 @@ SELECT
     END AS schedule_state,
     asgn_count.schedule_id
 FROM asgn_count;
+
+CREATE VIEW schedule_counts AS
+WITH
+    member_count AS (
+        SELECT
+            s.id AS schedule_id,
+            COUNT(usm.id) AS total_members
+        FROM schedule AS s
+        LEFT JOIN user_schedule_membership AS usm ON s.id = usm.schedule_id
+        WHERE s.removed IS NULL
+        GROUP BY s.id
+    ),
+    shift_count AS (
+        SELECT
+            s.id AS schedule_id,
+            COUNT(shift.id) AS total_shifts
+        FROM schedule AS s
+        LEFT JOIN shift ON s.id = shift.schedule_id
+        WHERE s.removed IS NULL
+        GROUP BY s.id
+    )
+SELECT
+    s.id AS schedule_id,
+    COALESCE(member_count.total_members, 0) AS total_members,
+    COALESCE(shift_count.total_shifts, 0) AS total_shifts
+FROM schedule AS s
+LEFT JOIN member_count ON s.id = member_count.schedule_id
+LEFT JOIN shift_count ON s.id = shift_count.schedule_id;

--- a/server/db/0.schema.sql
+++ b/server/db/0.schema.sql
@@ -35,6 +35,7 @@ CREATE TABLE user_schedule_membership
 ( id UUID PRIMARY KEY DEFAULT gen_random_uuid()
 , user_id UUID NOT NULL REFERENCES user_account (id) ON DELETE CASCADE
 , schedule_id UUID NOT NULL REFERENCES schedule (id) ON DELETE CASCADE
+, shift_count_offset INTEGER NOT NULL DEFAULT 0
 , UNIQUE (user_id, schedule_id)
 );
 

--- a/server/db/0.schema.sql
+++ b/server/db/0.schema.sql
@@ -178,7 +178,18 @@ WITH
 SELECT
     s.id AS schedule_id,
     COALESCE(member_count.total_members, 0) AS total_members,
-    COALESCE(shift_count.total_shifts, 0) AS total_shifts
+    COALESCE(shift_count.total_shifts, 0) AS total_shifts,
+    CASE
+        WHEN COALESCE(member_count.total_members, 0) = 0 THEN 0
+        ELSE FLOOR(COALESCE(shift_count.total_shifts, 0) * 1.0 / COALESCE(member_count.total_members, 1))
+    END AS min_shifts_per_employee,
+    CASE
+        WHEN COALESCE(member_count.total_members, 0) = 0 THEN 0
+        WHEN COALESCE(shift_count.total_shifts, 0) % COALESCE(member_count.total_members, 1) = 0 THEN
+            FLOOR(COALESCE(shift_count.total_shifts, 0) * 1.0 / COALESCE(member_count.total_members, 1))
+        ELSE
+            FLOOR(COALESCE(shift_count.total_shifts, 0) * 1.0 / COALESCE(member_count.total_members, 1)) + 1
+    END AS max_shifts_per_employee
 FROM schedule AS s
 LEFT JOIN member_count ON s.id = member_count.schedule_id
 LEFT JOIN shift_count ON s.id = shift_count.schedule_id;

--- a/server/db/1.test_data.sql
+++ b/server/db/1.test_data.sql
@@ -31,11 +31,11 @@ INSERT INTO schedule (id, removed, owner_id, schedule_name, schedule_description
   (gen_random_uuid(), NULL, (SELECT id FROM user_account WHERE username = 'user3'), 'Schedule 3', 'Description for Schedule 3', gen_random_uuid());
 
 -- Insert test data for user_schedule_membership
-INSERT INTO user_schedule_membership (id, user_id, schedule_id) VALUES
-  (gen_random_uuid(), (SELECT id FROM user_account WHERE username = 'user4'), (SELECT id FROM schedule WHERE schedule_name = 'Schedule 1')),
-  (gen_random_uuid(), (SELECT id FROM user_account WHERE username = 'user5'), (SELECT id FROM schedule WHERE schedule_name = 'Schedule 1')),
-  (gen_random_uuid(), (SELECT id FROM user_account WHERE username = 'user4'), (SELECT id FROM schedule WHERE schedule_name = 'Schedule 2')),
-  (gen_random_uuid(), (SELECT id FROM user_account WHERE username = 'user5'), (SELECT id FROM schedule WHERE schedule_name = 'Schedule 2'));
+INSERT INTO user_schedule_membership (id, user_id, schedule_id, shift_count_offset) VALUES
+  (gen_random_uuid(), (SELECT id FROM user_account WHERE username = 'user4'), (SELECT id FROM schedule WHERE schedule_name = 'Schedule 1'), 0),
+  (gen_random_uuid(), (SELECT id FROM user_account WHERE username = 'user5'), (SELECT id FROM schedule WHERE schedule_name = 'Schedule 1'), 0),
+  (gen_random_uuid(), (SELECT id FROM user_account WHERE username = 'user4'), (SELECT id FROM schedule WHERE schedule_name = 'Schedule 2'), 0),
+  (gen_random_uuid(), (SELECT id FROM user_account WHERE username = 'user5'), (SELECT id FROM schedule WHERE schedule_name = 'Schedule 2'), 0);
 
 -- Insert test data for shift
 INSERT INTO shift (id, schedule_id, start_time, end_time, shift_name, shift_description) VALUES

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -104,6 +104,12 @@ app.get(
   schedules.getUserAssignments,
 );
 
+app.post(
+  "/schedules/:scheduleId/recommended-shifts",
+  auth.authorizationCheck,
+  schedules.modifyRecommendedShifts,
+);
+
 app.get(
   "/shiftTreeCodeExisting",
   auth.authorizationCheck,

--- a/server/src/schedules.ts
+++ b/server/src/schedules.ts
@@ -942,3 +942,59 @@ export async function getCsv(req: Request, res: Response) {
 
   res.status(200).send({ csv: csvString });
 }
+
+export async function modifyRecommendedShifts(req: Request, res: Response) {
+  const userId = await getUserId(req);
+  const scheduleId = req.params.scheduleId;
+  const targetUserId = req.body.userId as string | null;
+  const newRecommendedShifts = req.body.recommendedNumShifts as number | null;
+
+  // Ensure that user exists and has perms to manage the schedule
+  {
+    const results = await pool.query({
+      text: /* sql */ `
+          select *
+          from schedule_info as info
+          where info.user_id = $1 and info.schedule_id = $2
+        `,
+      values: [userId, scheduleId],
+    });
+
+    if (results.rows.length < 1) {
+      res.status(404).json({
+        error: "Schedule not found or user does not exist",
+      });
+      return;
+    }
+
+    const role = results.rows[0].user_role;
+    if (!(role == "owner" || role == "manager")) {
+      res.status(403).json({
+        error:
+          "You do not have permission to modify the recommended shifts for a user",
+      });
+      return;
+    }
+  }
+
+  const query = /* sql */ `
+    update user_schedule_membership as usm
+    set shift_count_offset = $1 - sc.base_min_per_employee
+    from schedule_counts as sc
+    where usm.schedule_id = sc.schedule_id
+      and usm.user_id = $2 
+      and usm.schedule_id = $3
+  `;
+
+  const results = await pool.query({
+    text: query,
+    values: [newRecommendedShifts, targetUserId, scheduleId],
+  });
+
+  if (!results.rowCount || results.rowCount < 1) {
+    res.status(404).json({ error: "User not found" });
+    return;
+  }
+
+  res.status(204).send();
+}

--- a/server/src/schedules.ts
+++ b/server/src/schedules.ts
@@ -344,10 +344,16 @@ export async function getMembers(req: Request, res: Response) {
         'id', ua.id,
         'displayName', ua.username,
         'email', ua.email,
-        'profileImageUrl', ''
+        'profileImageUrl', '',
+        'suggestedShifts',
+          CASE
+            WHEN sc.base_min_per_employee + usm.shift_count_offset < 0 THEN 0
+            ELSE sc.base_min_per_employee + usm.shift_count_offset
+          END
       )), json_build_array()) as json
       from user_schedule_membership as usm
       join user_account as ua on usm.user_id = ua.id
+      join schedule_counts as sc on usm.schedule_id = sc.schedule_id
       where usm.schedule_id = $1
     `,
     values: [scheduleId],


### PR DESCRIPTION
- Managers can increase/decrease the recommended shifts for a user using arrows on the frontend
- They can submit their changes using a button
- DB stores this as an offset compared to the base min calculated as Floor[# Shifts / # Employees]
- Placed this in the Members tab
- Disabled the button if the manager hasn't made any changes