### PR TITLE
Combine view and edit pages

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -8,7 +8,6 @@ import Home from "@/Home.tsx";
 import Create from "@/Create.tsx";
 import Profile from "@/Profile.tsx";
 //import EditProfile from "@/EditProfile.tsx"; // To be added later
-import EditTree from "@/schedule/EditTree";
 import NotFoundPage from "@/NotFound.tsx";
 
 import { ThemeProvider } from "@mui/material/styles";
@@ -67,14 +66,6 @@ export default function App() {
                   }
                 />
                 */}
-                <Route
-                  path="/schedule/:scheduleId/edit"
-                  element={
-                    <Authenticated>
-                      <EditTree />
-                    </Authenticated>
-                  }
-                />
                 <Route
                   path="/schedule/:scheduleId"
                   element={

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -8,7 +8,6 @@ import Home from "@/Home.tsx";
 import Create from "@/Create.tsx";
 import Profile from "@/Profile.tsx";
 //import EditProfile from "@/EditProfile.tsx"; // To be added later
-import Schedule from "@/schedule/Schedule.tsx";
 import EditTree from "@/schedule/EditTree";
 import NotFoundPage from "@/NotFound.tsx";
 
@@ -16,6 +15,7 @@ import { ThemeProvider } from "@mui/material/styles";
 import customTheme from "./theme";
 import { NotifierProvider } from "@/notifier.tsx";
 import SignUpConfirmation from "./SignUpConfirmation.tsx";
+import ScheduleShared from "@/schedule/ScheduleShared.tsx";
 
 export default function App() {
   return (
@@ -79,7 +79,7 @@ export default function App() {
                   path="/schedule/:scheduleId"
                   element={
                     <Authenticated>
-                      <Schedule />
+                      <ScheduleShared />
                     </Authenticated>
                   }
                 />

--- a/client/src/customComponents/CustomTooltip.tsx
+++ b/client/src/customComponents/CustomTooltip.tsx
@@ -1,0 +1,17 @@
+import {
+  styled,
+  Tooltip,
+  tooltipClasses,
+  type TooltipProps,
+} from "@mui/material";
+
+export const CustomTooltip = styled(({ className, ...props }: TooltipProps) => (
+  <Tooltip {...props} arrow classes={{ popper: className }} />
+))(({ theme }) => ({
+  [`& .${tooltipClasses.arrow}`]: {
+    color: theme.palette.common.black,
+  },
+  [`& .${tooltipClasses.tooltip}`]: {
+    backgroundColor: theme.palette.common.black,
+  },
+}));

--- a/client/src/schedule/EditShiftsTab.tsx
+++ b/client/src/schedule/EditShiftsTab.tsx
@@ -8,11 +8,8 @@ import {
   Typography,
   Menu,
   MenuItem,
-  Tooltip,
-  TooltipProps,
-  tooltipClasses,
-  styled,
-  Grid,
+  Chip,
+  Avatar,
 } from "@mui/material";
 import React from "react";
 import dayjs from "dayjs";
@@ -44,23 +41,18 @@ import { useNotifier } from "@/notifier";
 import useSchedule from "@/hooks/useSchedule";
 import { useManagerActions } from "@/hooks/useManagerActions";
 import { downloadFile } from "@/utils";
+import { useEmployeeActions } from "@/hooks/useEmployeeActions";
+import { useApi } from "@/client";
+import { useShifts } from "@/hooks/useShifts";
+import { createRandomPfpUrl } from "@/schedule/EditMembersTab";
+import { CustomTooltip } from "@/customComponents/CustomTooltip";
 
 interface EditShiftsTabProps {
   scheduleId: string;
 }
 
-const CustomTooltip = styled(({ className, ...props }: TooltipProps) => (
-  <Tooltip {...props} arrow classes={{ popper: className }} />
-))(({ theme }) => ({
-  [`& .${tooltipClasses.arrow}`]: {
-    color: theme.palette.common.black,
-  },
-  [`& .${tooltipClasses.tooltip}`]: {
-    backgroundColor: theme.palette.common.black,
-  },
-}));
-
 export default function EditShiftsTab(props: EditShiftsTabProps) {
+  const { scheduleId } = props;
   const [currentlyEditing, setCurrentlyEditing] = useSearchParam("shift");
 
   //const navigate = useNavigate();
@@ -171,6 +163,35 @@ export default function EditShiftsTab(props: EditShiftsTabProps) {
     setAnchorEl(null);
   };
 
+  const empActions = useEmployeeActions(scheduleId);
+
+  function ManagerPerShiftStackContent(props: { shiftIds: string[] }) {
+    const shiftIds = useMemo(() => new Set(props.shiftIds), [props.shiftIds]);
+    const assignedUsers = useMemo(
+      () =>
+        empActions.allAssignments
+          ?.filter(asgn => asgn.shiftId && shiftIds.has(asgn.shiftId))
+          .map(asgn => asgn.user)
+          .filter(u => u !== undefined) ?? [],
+      [shiftIds],
+    );
+
+    return (
+      <>
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 0.5 }}>
+          {assignedUsers.map(user => (
+            <UserIndicators
+              key={user.id}
+              name={user.displayName}
+              id={user.id}
+              email={user.email}
+            />
+          ))}
+        </Box>
+      </>
+    );
+  }
+
   return (
     <Box
       sx={{
@@ -275,13 +296,14 @@ export default function EditShiftsTab(props: EditShiftsTabProps) {
             endDate={schedule.endTime}
             onClickShift={shiftId => setCurrentlyEditing(shiftId)}
             selectedShifts={currentlyEditing ? [currentlyEditing] : []}
+            CustomContent={ManagerPerShiftStackContent}
           />
         </>
       )}
       <EditShiftDrawer
         open={currentlyEditing != null}
         onClose={() => setCurrentlyEditing(null)}
-        title={"Edit shift"}
+        title={"Shift Details"}
       >
         {currentlyEditing && (
           <EditShift
@@ -422,6 +444,11 @@ function EditShift(props: EditShiftProps) {
 
   return (
     <>
+      <Typography sx={{ fontWeight: "bold" }}>Registered Members</Typography>
+      {/* Chips for users that are signed up */}
+      <UserChips scheduleId={props.scheduleId} shiftId={props.shiftId} />
+      <Divider sx={{ paddingTop: 1, paddingBottom: 1 }} />
+      <Typography sx={{ fontWeight: "bold" }}>Edit Shift</Typography>
       <Box sx={{ display: "flex", gap: 1 }}>
         <TextField
           id="name"
@@ -509,6 +536,7 @@ function EditShift(props: EditShiftProps) {
         </Button>
       </Box>
       <Divider sx={{ paddingTop: 1, paddingBottom: 1 }} />
+      <Typography sx={{ fontWeight: "bold" }}>Copy Shift</Typography>
       <Box
         sx={{
           display: "flex",
@@ -544,5 +572,75 @@ function EditShift(props: EditShiftProps) {
         </Box>
       </Box>
     </>
+  );
+}
+
+interface UserChipsProps {
+  scheduleId?: string;
+  shiftId?: string;
+}
+
+function UserChips(props: UserChipsProps) {
+  const api = useApi();
+
+  // This request is required to get the users that are signed up in each schedule
+  const { data: scheduleSignups } = api.useQuery(
+    "get",
+    "/schedules/{scheduleId}/signups",
+    { params: { path: { scheduleId: props.scheduleId as string } } },
+  );
+
+  const shifts = useShifts(props.scheduleId ?? "");
+
+  const stackShiftIds = useMemo(
+    () => new Set(shifts.matchingShifts(props.shiftId ?? "").map(s => s.id)),
+    [props.shiftId, shifts],
+  );
+
+  const users = scheduleSignups
+    ?.filter(shift => stackShiftIds.has(shift.id)) // Match the shiftId
+    .flatMap(shift => shift.signups?.map(signup => signup.user))
+    .filter(u => u !== undefined);
+
+  return (
+    <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1 }}>
+      {users?.map(user => {
+        return (
+          <CustomTooltip key={user.id} title={user.email}>
+            <Chip
+              avatar={
+                <Avatar src={createRandomPfpUrl(user.displayName, user.id)} />
+              }
+              label={user.displayName}
+              variant="outlined"
+            />
+          </CustomTooltip>
+        );
+      })}
+    </Box>
+  );
+}
+
+interface UserIndicatorsProps {
+  name: string;
+  id: string;
+  email: string;
+}
+
+function UserIndicators(props: UserIndicatorsProps) {
+  return (
+    <CustomTooltip title={props.email}>
+      <Chip
+        avatar={
+          <Avatar src={createRandomPfpUrl(props.name, props.id)}></Avatar>
+        }
+        sx={{
+          backgroundColor: theme => theme.palette.background.paper,
+          justifyContent: "space-between",
+        }}
+        label={props.name}
+        variant="outlined"
+      />
+    </CustomTooltip>
   );
 }

--- a/client/src/schedule/EditShiftsTab.tsx
+++ b/client/src/schedule/EditShiftsTab.tsx
@@ -17,8 +17,6 @@ import {
   Add as AddIcon,
   Delete as DeleteIcon,
   Save as SaveIcon,
-  Preview as PreviewIcon,
-  //EventRepeat as GenerateSchedule,
   AutoMode as GenerateSchedule,
   CloudDownload as DownloadIcon,
 } from "@mui/icons-material";
@@ -219,48 +217,31 @@ export default function EditShiftsTab(props: EditShiftsTabProps) {
               gap: 1,
             }}
           >
-            <Button
-              variant="contained"
-              component={RouterLink}
-              to={`/schedule/${props.scheduleId}`}
-              startIcon={<PreviewIcon />}
-              sx={{
-                backgroundColor: theme => theme.palette.info.main,
-              }}
-            >
-              <Typography>View mode</Typography>
-            </Button>
-            {schedule.data?.role == "owner" ||
-            schedule.data?.role == "manager" ? (
-              <CustomTooltip title="Create New Shift" placement="top">
-                <Button
-                  variant="contained"
-                  onClick={createNewShiftAndEdit}
-                  startIcon={<AddIcon />}
-                  sx={{
-                    backgroundColor: theme => theme.palette.info.light,
-                  }}
-                >
-                  <Typography>Add Shift</Typography>
-                </Button>
-              </CustomTooltip>
-            ) : null}
+            <CustomTooltip title="Create New Shift" placement="top">
+              <Button
+                variant="contained"
+                onClick={createNewShiftAndEdit}
+                startIcon={<AddIcon />}
+                sx={{
+                  backgroundColor: theme => theme.palette.info.light,
+                }}
+              >
+                <Typography>Add Shift</Typography>
+              </Button>
+            </CustomTooltip>
 
-            {schedule.data?.role == "owner" ||
-            schedule.data?.role == "manager" ? (
-              <CustomTooltip title="Auto-generate Schedule" placement="top">
-                <Button
-                  variant="contained"
-                  onClick={handleOpenModal}
-                  startIcon={<GenerateSchedule />}
-                  sx={{
-                    backgroundColor: theme => theme.palette.info.dark,
-                  }}
-                >
-                  <Typography>Generate</Typography>
-                </Button>
-              </CustomTooltip>
-            ) : null}
+            <CustomTooltip title="Auto-generate Schedule" placement="top">
+              <Button
+                variant="contained"
+                onClick={handleOpenModal}
+                startIcon={<GenerateSchedule />}
+                sx={{
+                  backgroundColor: theme => theme.palette.info.dark,
+                }}
+              >
+                <Typography>Generate</Typography>
+              </Button>
+            </CustomTooltip>
 
             <GenerateShiftModal
               open={modalOpen}

--- a/client/src/schedule/Schedule.tsx
+++ b/client/src/schedule/Schedule.tsx
@@ -11,11 +11,10 @@ import {
 } from "@mui/material";
 import { useParams } from "react-router";
 import {
-  Edit as EditIcon,
   HowToReg as RegisterIcon,
   EventBusy as LeaveShiftTreeIcon,
 } from "@mui/icons-material";
-import { Link as RouterLink, useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router-dom";
 import { useMemo, useState, useEffect } from "react";
 import dayjs from "dayjs";
 
@@ -116,9 +115,6 @@ export default function Schedule() {
     clearSelectedShift();
   }
 
-  const isManager =
-    scheduleData?.role == "manager" || scheduleData?.role == "owner";
-
   const isSignedUpForSelectedShift = useMemo(
     () => selectedShift && signedUpShifts.includes(selectedShift),
     [selectedShift, signedUpShifts],
@@ -164,93 +160,72 @@ export default function Schedule() {
             <Grid
               sx={{ display: "flex", flexDirection: "row-reverse", gap: 1 }}
             >
-              {isManager ? (
-                <Button
-                  variant="contained"
-                  startIcon={<EditIcon />}
-                  component={RouterLink}
-                  to={`/schedule/${scheduleId}/edit`}
-                  sx={{
-                    backgroundColor: theme => theme.palette.info.main,
-                  }}
-                >
-                  Edit mode
-                </Button>
-              ) : null}
-              {!isManager ? (
-                <Button
-                  variant="contained"
-                  startIcon={<LeaveShiftTreeIcon />}
-                  sx={{
-                    backgroundColor: theme => theme.palette.error.dark,
-                  }}
-                >
-                  <Typography>Leave Shift Tree</Typography>
-                </Button>
-              ) : null}
+              <Button
+                variant="contained"
+                startIcon={<LeaveShiftTreeIcon />}
+                sx={{
+                  backgroundColor: theme => theme.palette.error.dark,
+                }}
+              >
+                <Typography>Leave Shift Tree</Typography>
+              </Button>
             </Grid>
           </Grid>
           <Divider sx={{ my: 2 }} />
           <EditShiftDrawer
             open={drawerOpen}
             onClose={clearSelectedShift}
-            title={isManager ? "Shift Info" : "Sign-Up"}
+            title={"Sign-Up"}
           >
-            {!isManager && (
-              <>
-                <Box
-                  sx={{
-                    display: "flex",
-                    flexDirection: "column",
-                    alignItems: "flex-start",
-                    gap: 1,
-                  }}
-                >
-                  <CustomTooltip
-                    title="(Note:
+            <Box
+              sx={{
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "flex-start",
+                gap: 1,
+              }}
+            >
+              <CustomTooltip
+                title="(Note:
                       All your weights will be averaged. i.e. A weight of 100
                       for all registered shifts is equivalent to putting down 50
                       for all of them)"
-                    placement="top"
-                  >
-                    <Typography gutterBottom>
-                      Request Weight: How badly do you want this shift?{" "}
-                    </Typography>
-                  </CustomTooltip>
-                  <Slider
-                    defaultValue={50}
-                    aria-label="Request weight"
-                    valueLabelDisplay="auto"
-                    sx={{ width: { md: 300 } }}
-                    shiftStep={30}
-                    step={10}
-                    marks
-                    max={100}
-                    min={10}
-                  />
+                placement="top"
+              >
+                <Typography gutterBottom>
+                  Request Weight: How badly do you want this shift?{" "}
+                </Typography>
+              </CustomTooltip>
+              <Slider
+                defaultValue={50}
+                aria-label="Request weight"
+                valueLabelDisplay="auto"
+                sx={{ width: { md: 300 } }}
+                shiftStep={30}
+                step={10}
+                marks
+                max={100}
+                min={10}
+              />
 
-                  <Button
-                    variant="contained"
-                    color="primary"
-                    startIcon={<RegisterIcon />}
-                    sx={{
-                      backgroundColor: theme => theme.palette.success.main,
-                      "&:hover": {
-                        backgroundColor: theme => theme.palette.success.dark,
-                      },
-                      color: "white",
-                    }}
-                    onClick={
-                      isSignedUpForSelectedShift
-                        ? handleUnregister
-                        : handleRegister
-                    }
-                  >
-                    {isSignedUpForSelectedShift ? "Unregister" : "Register"}
-                  </Button>
-                </Box>
-              </>
-            )}
+              <Button
+                variant="contained"
+                color="primary"
+                startIcon={<RegisterIcon />}
+                sx={{
+                  backgroundColor: theme => theme.palette.success.main,
+                  "&:hover": {
+                    backgroundColor: theme => theme.palette.success.dark,
+                  },
+                  color: "white",
+                }}
+                onClick={
+                  isSignedUpForSelectedShift ? handleUnregister : handleRegister
+                }
+              >
+                {isSignedUpForSelectedShift ? "Unregister" : "Register"}
+              </Button>
+            </Box>
           </EditShiftDrawer>
           <ShiftCalendar
             onClickShift={shiftId => setSelectedShift(shiftId)}

--- a/client/src/schedule/Schedule.tsx
+++ b/client/src/schedule/Schedule.tsx
@@ -8,11 +8,6 @@ import {
   Chip,
   Box,
   Slider,
-  Avatar,
-  Tooltip,
-  TooltipProps,
-  tooltipClasses,
-  styled,
 } from "@mui/material";
 import { useParams } from "react-router";
 import {
@@ -29,22 +24,10 @@ import Navbar from "@/Navbar";
 import NavbarPadding from "@/NavbarPadding";
 import EditShiftDrawer from "./EditShiftDrawer";
 import { ShiftCalendar, ShiftDetails } from "./ShiftCalendar";
-import { createRandomPfpUrl } from "./EditMembersTab";
 import { useEmployeeActions } from "@/hooks/useEmployeeActions";
 import theme from "@/theme";
 import { useNotifier } from "@/notifier";
-import { useShifts } from "@/hooks/useShifts";
-
-const CustomTooltip = styled(({ className, ...props }: TooltipProps) => (
-  <Tooltip {...props} arrow classes={{ popper: className }} />
-))(({ theme }) => ({
-  [`& .${tooltipClasses.arrow}`]: {
-    color: theme.palette.common.black,
-  },
-  [`& .${tooltipClasses.tooltip}`]: {
-    backgroundColor: theme.palette.common.black,
-  },
-}));
+import { CustomTooltip } from "@/customComponents/CustomTooltip";
 
 function useSelectedShiftParam() {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -140,26 +123,6 @@ export default function Schedule() {
     () => selectedShift && signedUpShifts.includes(selectedShift),
     [selectedShift, signedUpShifts],
   );
-
-  function ManagerPerShiftStackContent(props: { shiftIds: string[] }) {
-    const shiftIds = useMemo(() => new Set(props.shiftIds), [props.shiftIds]);
-    const assignedUsers = useMemo(
-      () =>
-        empActions.allAssignments
-          ?.filter(asgn => asgn.shiftId && shiftIds.has(asgn.shiftId))
-          .map(asgn => asgn.user)
-          .filter(u => u !== undefined) ?? [],
-      [shiftIds],
-    );
-
-    return (
-      <>
-        {assignedUsers.map(user => (
-          <UserIndicators key={user.id} name={user.displayName} id={user.id} />
-        ))}
-      </>
-    );
-  }
 
   function MemberPerShiftStackContent(props: { shiftIds: string[] }) {
     const isRegistered = useMemo(
@@ -288,17 +251,6 @@ export default function Schedule() {
                 </Box>
               </>
             )}
-            {isManager && (
-              <>
-                <Typography variant="h6">Registered Members</Typography>
-                {/* Chips for users that are signed up */}
-
-                <UserChips
-                  scheduleId={scheduleId}
-                  shiftId={selectedShift ?? undefined}
-                ></UserChips>
-              </>
-            )}
           </EditShiftDrawer>
           <ShiftCalendar
             onClickShift={shiftId => setSelectedShift(shiftId)}
@@ -306,11 +258,7 @@ export default function Schedule() {
             endDate={dayjs(scheduleData?.endTime ?? dayjs().toISOString())}
             selectedShifts={selectedShift ? [selectedShift] : []}
             shifts={formattedShifts}
-            CustomContent={
-              isManager
-                ? ManagerPerShiftStackContent
-                : MemberPerShiftStackContent
-            }
+            CustomContent={MemberPerShiftStackContent}
           />
         </Paper>
       </Container>
@@ -342,69 +290,5 @@ function AssignedIndicator() {
       label="Assigned"
       color="primary"
     />
-  );
-}
-
-interface UserIndicatorsProps {
-  name: string;
-  id: string;
-}
-
-function UserIndicators(props: UserIndicatorsProps) {
-  return (
-    <Chip
-      avatar={<Avatar src={createRandomPfpUrl(props.name, props.id)}></Avatar>}
-      sx={{
-        backgroundColor: theme.palette.primary.main,
-        color: "white",
-      }}
-      label={props.name}
-      color="primary"
-    />
-  );
-}
-
-interface UserChipsProps {
-  scheduleId?: string;
-  shiftId?: string;
-}
-
-function UserChips(props: UserChipsProps) {
-  const api = useApi();
-
-  // This request is required to get the users that are signed up in each schedule
-  const { data: scheduleSignups } = api.useQuery(
-    "get",
-    "/schedules/{scheduleId}/signups",
-    { params: { path: { scheduleId: props.scheduleId as string } } },
-  );
-
-  const shifts = useShifts(props.scheduleId ?? "");
-
-  const stackShiftIds = useMemo(
-    () => new Set(shifts.matchingShifts(props.shiftId ?? "").map(s => s.id)),
-    [props.shiftId, shifts],
-  );
-
-  const users = scheduleSignups
-    ?.filter(shift => stackShiftIds.has(shift.id)) // Match the shiftId
-    .flatMap(shift => shift.signups?.map(signup => signup.user))
-    .filter(u => u !== undefined);
-
-  return (
-    <Box>
-      {users?.map(user => {
-        return (
-          <Chip
-            key={user.id}
-            avatar={
-              <Avatar src={createRandomPfpUrl(user.displayName, user.id)} />
-            }
-            label={user.displayName}
-            variant="outlined"
-          />
-        );
-      })}
-    </Box>
   );
 }

--- a/client/src/schedule/ScheduleShared.tsx
+++ b/client/src/schedule/ScheduleShared.tsx
@@ -1,0 +1,27 @@
+import { useApi } from "@/client";
+import EditTree from "@/schedule/EditTree";
+import Schedule from "@/schedule/Schedule";
+import { useParams } from "react-router";
+
+export default function ScheduleShared() {
+  const { scheduleId } = useParams();
+  const isManager = useIsManager(scheduleId ?? "");
+
+  if (isManager) {
+    return <EditTree />;
+  } else {
+    return <Schedule />;
+  }
+}
+
+export function useIsManager(scheduleId: string) {
+  const api = useApi();
+
+  const { data: scheduleData } = api.useQuery(
+    "get",
+    "/schedules/{scheduleId}",
+    { params: { path: { scheduleId: scheduleId as string } } },
+  );
+
+  return scheduleData?.role == "manager" || scheduleData?.role == "owner";
+}


### PR DESCRIPTION
- Unified page to just /schedules/:id, so manager and user see different pages
- Moved the registered users view in side panel and assigned users in shift cards (for manager) to the edit page
- Removed the switch view buttons and some old code checking if the user is manager (only need this in one place now)