### PR TITLE
Display some info through info icon w/ tooltip on schedule page

### DIFF
--- a/client/src/schedule/Schedule.tsx
+++ b/client/src/schedule/Schedule.tsx
@@ -8,7 +8,12 @@ import {
   Chip,
   Box,
   Slider,
+  IconButton,
   Avatar,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
   Tooltip,
   TooltipProps,
   tooltipClasses,
@@ -19,6 +24,7 @@ import {
   Edit as EditIcon,
   HowToReg as RegisterIcon,
   EventBusy as LeaveShiftTreeIcon,
+  Info as InfoIcon,
 } from "@mui/icons-material";
 import { Link as RouterLink, useSearchParams } from "react-router-dom";
 import { useMemo, useState, useEffect } from "react";
@@ -181,6 +187,11 @@ export default function Schedule() {
     }
   }
 
+  const [infoModalOpen, setInfoModalOpen] = useState(false);
+
+  const handleOpenSTInfo = () => setInfoModalOpen(true);
+  const handleCloseSTInfo = () => setInfoModalOpen(false);
+
   return (
     <Grid container direction="column" spacing={1}>
       <Navbar />
@@ -195,8 +206,41 @@ export default function Schedule() {
       >
         <Paper elevation={3} sx={{ padding: 2 }}>
           <Grid container justifyContent="space-between" alignItems="center">
-            <Grid sx={{ paddingLeft: 2, paddingBottom: 1, paddingTop: 1 }}>
+            <Grid
+              container
+              alignItems="center"
+              display="flex"
+              sx={{ paddingLeft: 2, paddingBottom: 0, paddingTop: 1 }}
+            >
               <Typography variant="h5">{scheduleData?.name}</Typography>
+
+              <CustomTooltip
+                title="Information About This ShiftTree"
+                placement="right"
+              >
+                <IconButton onClick={handleOpenSTInfo}>
+                  <InfoIcon />
+                </IconButton>
+              </CustomTooltip>
+
+              <Dialog open={infoModalOpen} onClose={handleCloseSTInfo}>
+                <DialogTitle>{scheduleData?.name} Information</DialogTitle>
+                <DialogContent>
+                  <Typography>
+                    Manager: {scheduleData?.owner?.displayName}
+                    <br />
+                    Manager Email: {scheduleData?.owner?.email}
+                    <br />
+                    Number of Shifts: {shifts?.length}
+                    <br />
+                  </Typography>
+                </DialogContent>
+                <DialogActions>
+                  <Button onClick={handleCloseSTInfo} color="primary">
+                    Close
+                  </Button>
+                </DialogActions>
+              </Dialog>
             </Grid>
             <Grid
               sx={{ display: "flex", flexDirection: "row-reverse", gap: 1 }}


### PR DESCRIPTION
- Just a tooltipped info icon that pops open a modal showing the manager username, email, and the # of shifts in the schedule as a bonus
- Text inside modal is not styled, not sure how to cleanly style within typography